### PR TITLE
Follow Posix standards when interpreting the directory separator.

### DIFF
--- a/lib/IO/Glob.pm6
+++ b/lib/IO/Glob.pm6
@@ -340,7 +340,8 @@ method !compile-glob() {
 
 method !compile-globs() {
     ($!volume,) = $.spec.splitpath($.pattern, :nofile);
-    my @parts = $.pattern.split($.spec.dir-sep);
+    my $delim = $.spec.dir-sep;
+    my @parts = $.pattern.split(/ $delim + /);
 
     $!absolute = (@parts[0] eq $!volume);
     shift @parts if $!absolute;


### PR DESCRIPTION
Two consecutive slashes are implementation defined while three or more are treated as a single slash.  Our implementation definition for two slashes is to also treated as a single slash